### PR TITLE
Add splashscreen with animation/logo

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,12 +1,23 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import HomePage from "./components/HomePage";
 import DarkModeToggle from "./components/DarkModeToggle";
 import DevTools from "./components/DevTools";
 import ApiTester from "./components/tests/ApiTester";
 import NetworkHealth from "./components/NetworkHealth";
 import QRCodeDisplay from "./components/QRCodeDisplay";
+import SplashScreen from "./components/SplashScreen";
 
 export function App() {
+  const [showSplash, setShowSplash] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowSplash(false);
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, []);
+
   // Check if we're in development mode
   const isDev = window.location.hostname === 'localhost' || 
                 window.location.hostname === '127.0.0.1' || 
@@ -17,7 +28,7 @@ export function App() {
       <div className="fixed top-4 right-4 z-50">
         <DarkModeToggle />
       </div>
-      <HomePage />
+      {showSplash ? <SplashScreen /> : <HomePage />}
       {isDev && <ApiTester />}          
       {isDev && <DevTools />}  
       <NetworkHealth />

--- a/frontend/src/components/SplashScreen.tsx
+++ b/frontend/src/components/SplashScreen.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+const SplashScreen: React.FC = () => {
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      navigate('/home');
+    }, 3000);
+
+    return () => clearTimeout(timer);
+  }, [navigate]);
+
+  return (
+    <div className="splash-screen">
+      <img src="/path/to/logo.png" alt="Logo" className="logo" />
+    </div>
+  );
+};
+
+export default SplashScreen;


### PR DESCRIPTION
Add a SplashScreen component with a 3-second delay before navigating to the HomePage.

* **frontend/src/components/SplashScreen.tsx**: Create a new SplashScreen component that displays a logo and navigates to the HomePage after 3 seconds using `useEffect` and `setTimeout`.
* **frontend/src/App.tsx**: Import the SplashScreen component. Add state to manage whether to show the SplashScreen or HomePage. Render the SplashScreen initially and switch to the HomePage after 3 seconds.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sisovin/lynx-notes-app/pull/1?shareId=ecb5dfdf-9388-4a65-9346-bb62d083fd71).